### PR TITLE
Add support for admonition

### DIFF
--- a/lib/asciidoctor/pdf/linewrap/ja.rb
+++ b/lib/asciidoctor/pdf/linewrap/ja.rb
@@ -46,6 +46,13 @@ Extensions.register do
         raw_text = get_raw_text(list_item)
         list_item.text = Asciidoctor::Pdf::Linewrap::Ja::Converter::insert_zero_width_space(raw_text)
       end
+
+      admonitions = document.find_by context: :admonition
+      admonitions.each do |admonition|
+        admonition.lines.each_with_index do |line, i|
+          admonition.lines[i] = Asciidoctor::Pdf::Linewrap::Ja::Converter::insert_zero_width_space(line)
+        end
+      end
     end
 
     def get_raw_text(item)


### PR DESCRIPTION
Asciidoctor PDF 向けの素晴らしい日本語禁則処理ライブラリーを公開していだきましてありがとうございます。 いつも活用させていただいております。

Asciidoc 文法のインライン脚注系（NOTE、TIP、IMPORTANT等）にて禁則処理が効くように処理を追加してみました。

[次のような文章](https://h1romas4.github.io/asciidoctor-gradle-template/index.pdf)で禁則処理が適用されるようになります。

```
NOTE: Java 実行環境は、文書変換スクリプトを動作させる過程で唯一 OS 環境に手動で導入する必要があるプロダクトです。それ以外のものは Gradle によりプロジェクトとして独立した形で自動的に導入されます。
```

もし良ければですがプルリクエストを取り込んでいただければと思います。

以上、お忙しいところ大変恐縮です。どうぞよろしくお願いいたします。